### PR TITLE
ORION-66: Augment authentication failure messages

### DIFF
--- a/bundles/org.eclipse.orion.server.authentication/src/org/eclipse/orion/server/authentication/formoauth/FormAuthenticationService.java
+++ b/bundles/org.eclipse.orion.server.authentication/src/org/eclipse/orion/server/authentication/formoauth/FormAuthenticationService.java
@@ -73,8 +73,9 @@ public class FormAuthenticationService implements IAuthenticationService {
 				result.put("SignInLocation", req.getContextPath() + FormAuthHelper.loginWindowURI());
 				result.put("label", "Orion workspace server");
 				result.put("SignInKey", "FORMOAuthUser");
+				result.put("status", HttpServletResponse.SC_UNAUTHORIZED);
 			} catch (JSONException e) {
-				LogHelper.log(new Status(IStatus.ERROR, Activator.PI_AUTHENTICATION_SERVLETS, 1, "An error occured during authenitcation", e));
+				LogHelper.log(new Status(IStatus.ERROR, Activator.PI_AUTHENTICATION_SERVLETS, 1, "An error occured during authentication", e));
 			}
 			resp.getWriter().print(result.toString());
 		}


### PR DESCRIPTION
-- orion's front-end expects errors to be in the form of an
   orionError (or a serialized form), as the error handling
   stack eventually hits "status.js#retrieveStatus"
-- change the result from being a plain JSONObject to union
   with a ServerStatus JSONObject
-- This change handles the case when the front-end tries to
   authenticate with its cached loginData (see
   sshTools.js#SshService._authService.getUser()). In
   particular, it does not handle the case when the user
   has NOT cloned successfully for a first time

QE: Please test that after a successful clone, if the user's
    session times out (eg logged out in another tab) and the
    user tries to clone again, the user will get an error
    of the form "An error occured during authentication".
    Please also test this with Multipass, as I've only
    tested this with simple FormOAuth.
